### PR TITLE
Update API call to fetch pull requests with sorting

### DIFF
--- a/update-versions.sh
+++ b/update-versions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-branch=$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/lidarr/lidarr/pulls?state=open&base=develop" | jq -re 'sort_by(.updated_at) | .[] | select((.head.repo.full_name == "Lidarr/Lidarr") and (.head.ref | contains("dependabot") | not)) | .head.ref') || exit 1
+branch=$(curl -u "${GITHUB_ACTOR}:${GITHUB_TOKEN}" -fsSL "https://api.github.com/repos/lidarr/lidarr/pulls?state=open&base=develop&sort=updated&direction=desc" | jq -re 'sort_by(.updated_at) | .[] | select((.head.repo.full_name == "Lidarr/Lidarr") and (.head.ref | contains("dependabot") | not)) | .head.ref') || exit 1
 branch=$(tail -n 1 <<< "${branch}")
 version=$(curl -fsSL "https://lidarr.servarr.com/v1/update/${branch}/changes?os=linuxmusl&runtime=netcore&arch=x64" | jq -re '.[0].version') || exit 1
 curl -fsSL "https://lidarr.servarr.com/v1/update/${branch}/updatefile?version=${version}&os=linuxmusl&runtime=netcore&arch=x64" -o /dev/null || exit 1


### PR DESCRIPTION
Due to the default `per_page` of 30, the `plugins` branch is on the second page and it's being skipped from updates. 